### PR TITLE
Use exceptions to propagate metamodel registration failures to user

### DIFF
--- a/plugins-server/org.hawk.service.servlet/src/org/hawk/service/servlet/config/HawkServerConfigurator.java
+++ b/plugins-server/org.hawk.service.servlet/src/org/hawk/service/servlet/config/HawkServerConfigurator.java
@@ -155,7 +155,11 @@ public class HawkServerConfigurator  {
 				@Override
 				public Void call() {
 					// add metamodels, Do it first before adding attributes or repositories
-					addMetamodels(hModel, config);
+					try { 
+						addMetamodels(hModel, config);
+					} catch (Exception e) {
+						LOGGER.error("Configuring Hawk instance: Exception when adding metamodels");
+					}
 
 					// add repositories, don't delete any
 					addMissingRepositories(hModel, config);
@@ -241,7 +245,7 @@ public class HawkServerConfigurator  {
 	}
 	}
 
-	private void addMetamodels(HModel hawkInstance, HawkInstanceConfig config) {
+	private void addMetamodels(HModel hawkInstance, HawkInstanceConfig config) throws Exception {
 		for (MetamodelParameters params : config.getMetamodels()) {
 			if(params.getLocation() != null && !params.getLocation().isEmpty()) {
 				File file = new File(params.getLocation());

--- a/plugins-server/org.hawk.service.servlet/src/org/hawk/service/servlet/processors/HawkThriftIface.java
+++ b/plugins-server/org.hawk.service.servlet/src/org/hawk/service/servlet/processors/HawkThriftIface.java
@@ -301,7 +301,11 @@ public final class HawkThriftIface implements Hawk.Iface {
 		}
 
 		final java.io.File[] fArray = files.toArray(new java.io.File[files.size()]);
-		model.registerMeta(fArray);
+		try {
+			model.registerMeta(fArray);
+		} catch (Exception e) {
+			throw new InvalidMetamodel(e.getMessage());
+		}
 	}
 
 	@Override

--- a/plugins/org.hawk.core/src/org/hawk/core/FailedMetamodelRegistrationException.java
+++ b/plugins/org.hawk.core/src/org/hawk/core/FailedMetamodelRegistrationException.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Aston University.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License, v. 2.0 are satisfied: GNU General Public License, version 3.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-3.0
+ *
+ * Contributors:
+ *     Antonio Garcia-Dominguez - original idea and implementation
+ ******************************************************************************/
+package org.hawk.core;
+
+public class FailedMetamodelRegistrationException extends Exception {
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 5729317672040153337L;
+
+	public FailedMetamodelRegistrationException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public FailedMetamodelRegistrationException(String message) {
+		super(message);
+	}
+
+	public FailedMetamodelRegistrationException(Throwable cause) {
+		super(cause);
+	}
+	
+}

--- a/plugins/org.hawk.core/src/org/hawk/core/IMetaModelUpdater.java
+++ b/plugins/org.hawk.core/src/org/hawk/core/IMetaModelUpdater.java
@@ -26,8 +26,8 @@ public interface IMetaModelUpdater extends IHawkPlugin {
 	/**
 	 * @return <code>true</code> if insertion was successful, <code>false</code> otherwise.
 	 */
-	boolean insertMetamodels(Set<IHawkMetaModelResource> set,
-			IModelIndexer indexer);
+	void insertMetamodels(Set<IHawkMetaModelResource> set,
+			IModelIndexer indexer) throws FailedMetamodelRegistrationException;
 
 	void run();
 

--- a/plugins/org.hawk.core/src/org/hawk/core/IVcsManager.java
+++ b/plugins/org.hawk.core/src/org/hawk/core/IVcsManager.java
@@ -37,9 +37,9 @@ public interface IVcsManager extends IHawkPlugin {
 	String getFirstRevision() throws Exception;
 
 	/**
-	 * Returns the set of changed items on this revision.
+	 * Returns the set of changed items from this revision.
 	 */
-	Collection<VcsCommitItem> getDelta(String endRevision) throws Exception;
+	Collection<VcsCommitItem> getDelta(String startRevision) throws Exception;
 
 	/**
 	 * Returns the set of changed items between these revisions.

--- a/plugins/org.hawk.core/src/org/hawk/core/runtime/BaseModelIndexer.java
+++ b/plugins/org.hawk.core/src/org/hawk/core/runtime/BaseModelIndexer.java
@@ -489,12 +489,10 @@ public abstract class BaseModelIndexer implements IModelIndexer {
 	
 		}
 
-		// if metamodels added successfully
-		if (metamodelupdater.insertMetamodels(set, this)) {
-			// reset repositories as models may be parsable in them
-			for (IVcsManager s : monitors) {
-				resetRepository(s.getLocation());
-			}
+		// reset repositories as models may be parsable in them
+		metamodelupdater.insertMetamodels(set, this);
+		for (IVcsManager s : monitors) {
+			resetRepository(s.getLocation());
 		}
 		stateListener.info("Added metamodel(s).");
 	}

--- a/plugins/org.hawk.graph/src/org/hawk/graph/updater/GraphMetaModelUpdater.java
+++ b/plugins/org.hawk.graph/src/org/hawk/graph/updater/GraphMetaModelUpdater.java
@@ -18,28 +18,26 @@ package org.hawk.graph.updater;
 
 import java.util.Set;
 
+import org.hawk.core.FailedMetamodelRegistrationException;
 import org.hawk.core.IMetaModelUpdater;
 import org.hawk.core.IModelIndexer;
 import org.hawk.core.model.IHawkMetaModelResource;
 import org.hawk.core.runtime.CompositeGraphChangeListener;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class GraphMetaModelUpdater implements IMetaModelUpdater {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(GraphMetaModelUpdater.class);
-
 	@Override
-	public boolean insertMetamodels(Set<IHawkMetaModelResource> set,
-			IModelIndexer indexer) {
+	public void insertMetamodels(Set<IHawkMetaModelResource> set, IModelIndexer indexer)
+			throws FailedMetamodelRegistrationException
+	{
 		try {
 			new GraphMetaModelResourceInjector(indexer, set,
-					(CompositeGraphChangeListener) indexer
-							.getCompositeGraphChangeListener());
-			return true;
-		} catch (Exception e) {
-			LOGGER.error("Metamodel insertion failed", e);
-			return false;
+				(CompositeGraphChangeListener) indexer
+						.getCompositeGraphChangeListener());
+		} catch (FailedMetamodelRegistrationException ex) {
+			throw ex;
+		} catch (Exception ex) {
+			throw new FailedMetamodelRegistrationException(ex);
 		}
 	}
 

--- a/plugins/org.hawk.localfolder/src/org/hawk/localfolder/LocalFolder.java
+++ b/plugins/org.hawk.localfolder/src/org/hawk/localfolder/LocalFolder.java
@@ -197,7 +197,6 @@ public class LocalFolder extends FileBasedLocation {
 
 	@Override
 	public VcsRepositoryDelta getDelta(String startRevision, String endRevision) throws Exception {
-
 		VcsRepositoryDelta delta = new VcsRepositoryDelta();
 		delta.setManager(this);
 

--- a/plugins/org.hawk.osgiserver/src/org/hawk/osgiserver/HModel.java
+++ b/plugins/org.hawk.osgiserver/src/org/hawk/osgiserver/HModel.java
@@ -542,14 +542,8 @@ public class HModel implements IStateListener {
 		return manager;
 	}
 
-	public boolean registerMeta(File... f) {
-		try {
-			hawk.getModelIndexer().registerMetamodels(f);
-		} catch (Exception e) {
-			getConsole().printerrln(e);
-			return false;
-		}
-		return true;
+	public void registerMeta(File... f) throws Exception {
+		hawk.getModelIndexer().registerMetamodels(f);
 	}
 
 	public void removeHawkFromMetadata(HawkConfig config) throws BackingStoreException {

--- a/plugins/org.hawk.ui2/src/org/hawk/ui2/dialog/HConfigDialog.java
+++ b/plugins/org.hawk.ui2/src/org/hawk/ui2/dialog/HConfigDialog.java
@@ -32,6 +32,7 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jface.dialogs.Dialog;
+import org.eclipse.jface.dialogs.ErrorDialog;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.TitleAreaDialog;
 import org.eclipse.jface.viewers.ArrayContentProvider;
@@ -61,6 +62,7 @@ import org.hawk.core.IVcsManager;
 import org.hawk.core.util.IndexedAttributeParameters;
 import org.hawk.osgiserver.HModel;
 import org.hawk.osgiserver.HModelSchedulingRule;
+import org.hawk.ui2.Activator;
 import org.hawk.ui2.view.HView;
 import org.osgi.framework.FrameworkUtil;
 
@@ -321,8 +323,7 @@ public class HConfigDialog extends TitleAreaDialog implements IStateListener {
 			}
 
 			if (!error) {
-				hawkModel.registerMeta(metaModelFiles);
-				updateMetamodelList();
+				registerMetamodels(metaModelFiles);
 			}
 		}
 	}
@@ -346,9 +347,20 @@ public class HConfigDialog extends TitleAreaDialog implements IStateListener {
 				files[i] = ((IFile)iFiles[i]).getLocation().toFile();
 			}
 
-			hawkModel.registerMeta(files);
-			updateMetamodelList();
+			registerMetamodels(files);
 		}
+	}
+
+	protected void registerMetamodels(File[] files) {
+		try {
+			hawkModel.registerMeta(files);
+		} catch (Exception e) {
+			ErrorDialog.openError(getShell(),
+				"Could not register metamodel",
+				"There was a problem while registering the metamodel",
+				new Status(IStatus.ERROR, Activator.PLUGIN_ID, "Failed to register metamodel", e));
+		}
+		updateMetamodelList();
 	}
 	
 	protected String[] getKnownMetamodelFilePatterns() {

--- a/plugins/org.hawk.workspace/src/org/hawk/workspace/Workspace.java
+++ b/plugins/org.hawk.workspace/src/org/hawk/workspace/Workspace.java
@@ -280,8 +280,8 @@ public class Workspace implements IVcsManager {
 	}
 
 	@Override
-	public Collection<VcsCommitItem> getDelta(String string) throws Exception {
-		return getDelta(string, getCurrentRevision()).getCompactedCommitItems();
+	public Collection<VcsCommitItem> getDelta(String startRevision) throws Exception {
+		return getDelta(startRevision, getCurrentRevision()).getCompactedCommitItems();
 	}
 
 	@Override


### PR DESCRIPTION
Fixes #87 

I have changed the metamodel registration core API so it uses exceptions to signal failure, rather than a boolean value. This allows us to propagate the cause of the issue, rather than just tell the user "no, sorry, it did not work out".